### PR TITLE
Removed the possibility to run a console consumer instead of the consumer Web UI

### DIFF
--- a/rh-summit-2018/module-02.adoc
+++ b/rh-summit-2018/module-02.adoc
@@ -46,11 +46,6 @@ image::route.png[route]
 
 image::web_ui.png[web ui]
 
-It's also possible to avoid running the consumer Web UI application and instead running a Kafka console consumer on one of the Pods of the deployed Kafka cluster.
-
-[source,sh]
-$ oc exec -it my-cluster-kafka-0 -- bin/kafka-console-consumer.sh --bootstrap-server my-cluster-kafka:9092 --topic iot-temperature-max --from-beginning
-
 === Deploy the stream application
 
 The stream application uses Kafka Streams API reading from the `iot-temperature` topic, processing its values and then putting the max temperature value in the specified time window into the `iot-temperature-max` topic.


### PR DESCRIPTION
@mbogoevici I preferred to remove the choice of running the consumer web ui or a Kafka console consumer on one of the pods. The attendees could be a little bit confused about that. Wdyt ?